### PR TITLE
Hcheng/add slice to mutator

### DIFF
--- a/superset/common/query_context_factory.py
+++ b/superset/common/query_context_factory.py
@@ -70,7 +70,7 @@ class QueryContextFactory:  # pylint: disable=too-few-public-methods
                 datasource_model_instance,
                 form_data,
                 self._query_object_factory.create(
-                    result_type, datasource=datasource, **query_obj
+                    result_type, datasource=datasource, slice_=slice_, **query_obj
                 ),
             )
             for query_obj in queries

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -107,6 +107,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
     time_shift: str | None
     time_range: str | None
     to_dttm: datetime | None
+    slice_id: int | None
 
     def __init__(  # pylint: disable=too-many-locals
         self,
@@ -132,6 +133,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         series_limit_metric: Metric | None = None,
         time_range: str | None = None,
         time_shift: str | None = None,
+        slice_id: int | None = None,
         **kwargs: Any,
     ):
         self._set_annotation_layers(annotation_layers)
@@ -161,6 +163,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         self.time_offsets = kwargs.get("time_offsets", [])
         self.inner_from_dttm = kwargs.get("inner_from_dttm")
         self.inner_to_dttm = kwargs.get("inner_to_dttm")
+        self.slice_id = getattr(kwargs.get("slice_"), "id", None)
         self._rename_deprecated_fields(kwargs)
         self._move_deprecated_extra_fields(kwargs)
 
@@ -335,6 +338,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             "series_limit_metric": self.series_limit_metric,
             "to_dttm": self.to_dttm,
             "time_shift": self.time_shift,
+            "slice_id": self.slice_id,
         }
         return query_object_dict
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1209,6 +1209,8 @@ DB_CONNECTION_MUTATOR = None
 def SQL_QUERY_MUTATOR(  # pylint: disable=invalid-name,unused-argument
     sql: str, **kwargs: Any
 ) -> str:
+    for key, value in reversed(list(kwargs.items())):
+        sql = f"-- {key}: {value}\n{sql}"
     return sql
 
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -816,7 +816,7 @@ class SqlaTable(
             df = pd.read_sql_query(sql=sql, con=engine)
             return df[column_name].to_list()
 
-    def mutate_query_from_config(self, sql: str) -> str:
+    def mutate_query_from_config(self, sql: str, **kwargs: Any) -> str:
         """Apply config's SQL_QUERY_MUTATOR
 
         Typically adds comments to the query with context"""
@@ -825,6 +825,8 @@ class SqlaTable(
         if sql_query_mutator and not mutate_after_split:
             sql = sql_query_mutator(
                 sql,
+                chart_id=f"{kwargs.get('query_obj', {}).get('slice_id', None)}",
+                dataset_id=self.id,
                 security_manager=security_manager,
                 database=self.database,
             )
@@ -843,7 +845,7 @@ class SqlaTable(
         sql = self._apply_cte(sql, sqlaq.cte)
         sql = sqlparse.format(sql, reindent=True)
         if mutate:
-            sql = self.mutate_query_from_config(sql)
+            sql = self.mutate_query_from_config(sql, query_obj=query_obj)
         return QueryStringExtended(
             applied_template_filters=sqlaq.applied_template_filters,
             applied_filter_columns=sqlaq.applied_filter_columns,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1409,6 +1409,7 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_sqla_query(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
         self,
+        slice_id: Optional[int] = None,
         apply_fetch_values_predicate: bool = False,
         columns: Optional[list[Column]] = None,
         extras: Optional[dict[str, Any]] = None,

--- a/tests/integration_tests/model_tests.py
+++ b/tests/integration_tests/model_tests.py
@@ -481,6 +481,7 @@ class TestSqlaTableModel(SupersetTestCase):
             to_dttm=None,
             extras=dict(time_grain_sqla="P1Y"),
             series_limit=15 if inner_join and is_timeseries else None,
+            slice_id=None,
         )
         qr = tbl.query(query_obj)
         self.assertEqual(qr.status, QueryStatus.SUCCESS)
@@ -531,6 +532,7 @@ class TestSqlaTableModel(SupersetTestCase):
             from_dttm=None,
             to_dttm=None,
             extras={},
+            slice_id=None,
         )
         sql = tbl.get_query_str(query_obj)
         self.assertNotIn("-- COMMENT", sql)
@@ -557,6 +559,7 @@ class TestSqlaTableModel(SupersetTestCase):
             from_dttm=None,
             to_dttm=None,
             extras={},
+            slice_id=None,
         )
         sql = tbl.get_query_str(query_obj)
         self.assertNotIn("-- COMMENT", sql)
@@ -571,6 +574,44 @@ class TestSqlaTableModel(SupersetTestCase):
 
         app.config["SQL_QUERY_MUTATOR"] = None
 
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_mutate_query_from_config_with_additional_params(self):
+        # Arrange
+        tbl = self.get_table(name="birth_names")
+        query_obj = dict(
+            groupby=[],
+            metrics=None,
+            filter=[],
+            is_timeseries=False,
+            columns=["name"],
+            granularity=None,
+            from_dttm=None,
+            to_dttm=None,
+            extras={},
+            slice_id=None,
+        )
+        sql = tbl.get_query_str(query_obj)
+        self.assertNotIn("-- COMMENT", sql)
+
+        def mutator(sql, database=None, **kwargs):
+            comment = "-- COMMENT\n--" + "\n" + str(database) + "\n"
+            for key, value in kwargs.items():
+                comment += f"-- {key}: {value}\n"
+            return comment + sql
+
+        # Act
+        app.config["SQL_QUERY_MUTATOR"] = mutator
+        app.config["MUTATE_AFTER_SPLIT"] = False
+        mutated_sql = tbl.mutate_query_from_config(sql, query_obj=query_obj)
+
+        # Assert
+        self.assertIn("-- COMMENT", mutated_sql)
+        self.assertIn(str(tbl.database), mutated_sql)
+
+        # Cleanup
+        app.config["SQL_QUERY_MUTATOR"] = None
+        app.config["MUTATE_AFTER_SPLIT"] = None
+
     def test_query_with_non_existent_metrics(self):
         tbl = self.get_table(name="birth_names")
 
@@ -584,6 +625,7 @@ class TestSqlaTableModel(SupersetTestCase):
             from_dttm=None,
             to_dttm=None,
             extras={},
+            slice_id=None,
         )
 
         with self.assertRaises(Exception) as context:

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -59,6 +59,7 @@ def test_default_query_object_to_dict():
         "series_limit_metric": None,
         "time_shift": None,
         "to_dttm": None,
+        "slice_id": None,
     }
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hi team,

We're looking to make a few changes that would allow folks to populate the `sql_query_mutator` with more useful params. We're open to discussion on the best practices to do so.

**These are the three items we're looking to change:**
- Change [mutate_query_from_config](https://github.com/hwmarkcheng/superset/pull/1/files#diff-af5e15a55ff9c81f441eb6b9b10dae13b2ee17fec614d3e3ad0057ed0dc814aeR819) to take in kwargs (Consistent with intended purpose of sql_query_mutator, see this [PR](https://github.com/apache/superset/pull/19083))
- Add `slice_id` to `query_obj `:  As addition context for `query_obj`. Having slice_id is versatile and can open doors for powerful integrations/automations. We originally wanted to add in the whole slice object for more options, but some integration tests failed since the object cannot be converted to a dictionary. Happy to discuss the best way to do this going forward.
- Add `chart_id` and `dataset_id` as default parameters for [mutate_query_from_config](https://github.com/hwmarkcheng/superset/pull/1/files)

**Example Usecase, Automated Data Access Requests via Satori:**
Context: We use Satori for our data access management.
- Users posts chart link to request access to specific schemas -> DAR team approves request -> We grab chart/dataset id from query -> Integrate with Satori to automatically identify all schemas in the chart and grant the user access to them

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

- Change [sql_query_mutator](https://github.com/hwmarkcheng/superset/pull/1/files#diff-c99ae4b2b09b756ab2189a99a9685229f9d12633fc2616c368ea869770f603bfR1212) to add kwargs as comments. **Note this will be reverted before committing (we don't want to change this)**
  - Click view query on any chart in a dashboard. You should now see the chart_id, as well as the dataset_id
  - <img width="1403" alt="Screenshot 2023-08-23 at 4 34 57 PM" src="https://github.com/hwmarkcheng/superset/assets/94201005/f5bbf10e-56cc-4609-a039-488bd3cd6e7b">

Changed query_obj tests to account for additional parameters:
- [model_tests.py](https://github.com/hwmarkcheng/superset/pull/1/files#diff-2ec392cd10be9b443aedbb76af31cd47b9aaa773c34df9353c8d854cefcd9d07R591)
- [query_object_test.py](https://github.com/hwmarkcheng/superset/pull/1/files#diff-9a8c5397a1fe57ae5a2ac0df4f3c1f687a5fef7e6f1c6f2ad2c25ccc124dd46eR62)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
